### PR TITLE
Add codespell support (config, workflow to detect/not fix) and make it fix few typos

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,6 @@
+[codespell]
+skip = .git,*.pdf,*.svg,go.sum,.codespellrc,po,*.po,*.pot
+check-hidden = true
+# ignore lines with German
+ignore-regex = .*ü.*
+ignore-words-list = childs,parm

--- a/ChangeLog
+++ b/ChangeLog
@@ -44,7 +44,7 @@ ChangeLog for davfs2
 
 2020-06-06 Werner Baumann (werner.baumann@onlinehome.de)
     * webdav.c, add_header:
-      Use ";" instead of "," as seperator (bug #58459).
+      Use ";" instead of "," as separator (bug #58459).
 
 2020-06-06 Werner Baumann (werner.baumann@onlinehome.de)
     * mount_davfs.c, log_dbg_config:
@@ -247,7 +247,7 @@ ChangeLog for davfs2
 
 2014-04-05 Werner Baumann (werner.baumann@onlinehome.de)
     * umount_davfs.c:
-      Allways try 'umount -i'.
+      Always try 'umount -i'.
 
 2014-04-05 Werner Baumann (werner.baumann@onlinehome.de)
     * configure.ac, src/Makefile.am, defaults.h,
@@ -343,7 +343,7 @@ ChangeLog for davfs2
 
 2012-11-01 Werner Baumann (werner.baumann@onlinehome.de)
     * man/Makefile.am, man/de/Makefile.am, man/es/Makefile.am:
-      Honour configrue parameter --manfile (sr #108173)
+      Honour configure parameter --manfile (sr #108173)
 
 2012-08-20 Werner Baumann (werner.baumann@onlinehome.de)
     * src/Makefile.am:
@@ -511,7 +511,7 @@ ChangeLog for davfs2
 
 2009-06-12 Werner Baumann (werner.baumann@onlinehome.de)
     * cache.c, set_next_upload_attempt:
-      Max. retry intervall for files must not exceed max_retry.
+      Max. retry interval for files must not exceed max_retry.
     * Add configuration option max_upload_attempts.
 
 2009-06-08 Werner Baumann (werner.baumann@onlinehome.de)
@@ -758,7 +758,7 @@ ChangeLog for davfs2
 2008-05-30 Werner Baumann (werner.baumann@onlinehome.de)
     * cache.c, parse_index:
       Finish parsing, before checking for parse error
-      (ne_xml_parse seems not allways to report
+      (ne_xml_parse seems not always to report
        errors otherwise)
     * cache.c, write_node:
       Put path, name, cache_path, etag and mime_type

--- a/ChangeLog
+++ b/ChangeLog
@@ -656,7 +656,7 @@ ChangeLog for davfs2
       Added missing licenses.
 
 2009-04-04 Werner Baumann (werner.baumann@onlinehome.de)
-    * cahe.c, dav_lookup:
+    * cache.c, dav_lookup:
       If node not found update directory with file_refresh.
 
 2009-03-29 Werner Baumann (werner.baumann@onlinehome.de)

--- a/NEWS
+++ b/NEWS
@@ -25,11 +25,11 @@ What is new in davfs2 1.6.0
 ===========================
 
 davfs2 no longer support the use of the Coda kernel file system. It would
-have required some chnges. But the fuse kernel file system si better suited
+have required some changes. But the fuse kernel file system si better suited
 anyway and is part of the official Linux kernel for many years now. So
 Coda is no longer required.
 
-The Neon library from version 0.31 on has a workaraound for some XML-bugs of
+The Neon library from version 0.31 on has a workaround for some XML-bugs of
 SharePoint concerning file names. Option "sharepoint_href_bug 1" will activate
 this workaround.
 
@@ -129,7 +129,7 @@ Support for Neon 0.29.
 Support for NTLM authentication (with Neon 0.29 only).
 
 Experimental support for commandline option "username" for use
-with pam_mount. I am not sure wether this is really usefull because
+with pam_mount. I am not sure wether this is really useful because
 I think that for typical use cases of pam_mount davfs2 is not
 well suited. Please report your experience with this option.
 
@@ -140,7 +140,7 @@ if a servercert is not trusted but silently not accept the certificate.
 What is new in davfs2 1.4.1
 ===========================
 
-For this version I got many bug fixes, informations and
+For this version I got many bug fixes, information and
 suggestions for improvement from Dirk Arend of the German
 company AVM. Thanks a lot.
 
@@ -152,7 +152,7 @@ and avoid useless further attempts.
 
 When attempts to upload changed files fail because of problems
 with the network connection, new upload attempts will be done with
-increasing time intervals to not waist bandwith with to many
+increasing time intervals to not waist bandwidth with to many
 useless attempts. When the davfs2 file system is unmounted while
 the connection is down changed files will stay in the cache and
 will be uploaded when the file system is mounted the next time.

--- a/NEWS
+++ b/NEWS
@@ -129,11 +129,11 @@ Support for Neon 0.29.
 Support for NTLM authentication (with Neon 0.29 only).
 
 Experimental support for commandline option "username" for use
-with pam_mount. I am not sure wether this is really useful because
+with pam_mount. I am not sure whether this is really useful because
 I think that for typical use cases of pam_mount davfs2 is not
 well suited. Please report your experience with this option.
 
-If option askauth ist set to 0 davfs2 will no longer ask the user
+If option askauth is set to 0 davfs2 will no longer ask the user
 if a servercert is not trusted but silently not accept the certificate.
 
 

--- a/THANKS
+++ b/THANKS
@@ -1,7 +1,7 @@
 davfs2 THANKS 2014-04-21
 ------------------------
 
-This file used to contain a list of contributers. But this list never was
+This file used to contain a list of contributors. But this list never was
 complete and I am not able to keep track of contributions.
 
 So I wand to thank all the people who helped in one or another way:

--- a/TODO
+++ b/TODO
@@ -3,7 +3,7 @@ davfs2 TODO 2014-04-21
 
 - write a GNU-style manual
 
-- multithreading for HTTP-requests and cache maintainance
+- multithreading for HTTP-requests and cache maintenance
 
 - restructure file name extraction and href construction
 

--- a/config/davfs2.m4
+++ b/config/davfs2.m4
@@ -24,7 +24,7 @@
 # AC_PATH_PROG to find 'neon-config'.
 # If found, it sets variable NEON_CONFIG and calls NEON_USE_EXTERNAL.
 # if not found, or if NEON_USE_EXTERNAL does not set neon_got_library
-# to yes, configration is stopped with an error message.
+# to yes, configuration is stopped with an error message.
 
 AC_DEFUN([DAV_CHECK_NEON],[
 
@@ -66,7 +66,7 @@ AC_DEFUN([DAV_CHECK_NEON],[
 ])
 
 
-# Setting uid and gid, mount.davfs will run as, and some pathes.
+# Setting uid and gid, mount.davfs will run as, and some paths.
 
 AC_DEFUN([DAV_DEFAULTS],[
 
@@ -151,7 +151,7 @@ AC_DEFUN([DAV_ICONV],[
 
     if test "$dav_iconv" = "yes"; then
         AC_DEFINE([DAV_USE_ICONV], [1],
-          [Define to enable charcter conversion])
+          [Define to enable character conversion])
     fi
 
 ])

--- a/config/neon.m4
+++ b/config/neon.m4
@@ -46,7 +46,7 @@
 #   ])
 #
 # Alternatively, for a simple standalone app with neon as a
-# dependancy, use just:
+# dependency, use just:
 #
 #   NEON_LIBRARY
 # 
@@ -341,7 +341,7 @@ AC_SUBST(NEON_BUILD_BUNDLED)
 dnl AC_SEARCH_LIBS done differently. Usage:
 dnl   NE_SEARCH_LIBS(function, libnames, [extralibs], [actions-if-not-found],
 dnl                            [actions-if-found])
-dnl Tries to find 'function' by linking againt `-lLIB $NEON_LIBS' for each
+dnl Tries to find 'function' by linking against `-lLIB $NEON_LIBS' for each
 dnl LIB in libnames.  If link fails and 'extralibs' is given, will also
 dnl try linking against `-lLIB extralibs $NEON_LIBS`.
 dnl Once link succeeds, `-lLIB [extralibs]` is prepended to $NEON_LIBS, and
@@ -644,7 +644,7 @@ else
 #include <netdb.h>])
    AC_CHECK_TYPE(in_addr_t,,[
      AC_DEFINE([in_addr_t], [unsigned int], 
-                            [Define if in_addr_t is not availale])], [
+                            [Define if in_addr_t is not available])], [
 #ifdef HAVE_SYS_TYPES_H
 # include <sys/types.h>
 #endif

--- a/man/davfs2.conf.5
+++ b/man/davfs2.conf.5
@@ -116,7 +116,7 @@ Default: 16
 .TP
 .B use_proxy
 Whether to use a proxy to connect to the WebDAV server. 0 = no, 1 = yes.
-If no proxy is defined in the configration file or the environment variables
+If no proxy is defined in the configuration file or the environment variables
 \fBhttps_proxy\fR, \fBhttp_proxy\fR and \fBall_proxy\fR, this option has no
 effect. 
 .br
@@ -189,7 +189,7 @@ and not by a top level CA then the TLS-specification requires the client
 to send the complete chain of certificates (without the top
 level CA-certificate). davfs2 only sends the client certificate. To work
 around this bug the server must store and trust the complete chain of
-CA-certificates down to the one CA that isssued the client certificate.
+CA-certificates down to the one CA that issued the client certificate.
 
 .TP
 .B secrets
@@ -251,7 +251,7 @@ Default: 0
 .TP
 .B if_match_bug
 Some servers do not handle If-Match and If-None-Match-headers correctly.
-This otion tells \fB@PROGRAM_NAME@\fR to use HEAD instead of thes headers.
+This option tells \fB@PROGRAM_NAME@\fR to use HEAD instead of thes headers.
 0 = no, 1 = yes.
 .br
 Default: 0
@@ -521,7 +521,7 @@ Default: 0
 Send debug messages to the syslog daemon. The value tells what kind of
 information shall be logged. The messages are send with facility LOG_DAEMON
 and priority LOG_DEBUG. It depends from the configuration of the syslog daemon
-where the messages will go (propably /var/log/messages, /var/log/syslog or
+where the messages will go (probably /var/log/messages, /var/log/syslog or
 /var/log/daemon.log). Whether HTTP related debug messages are available
 depends on your neon library.
 .br

--- a/man/davfs2.conf.5
+++ b/man/davfs2.conf.5
@@ -71,7 +71,7 @@ of \(cq\ \(cq, \(cq\(rs#\(cq instead of \(cq#\(cq, \(cq\(rs\(rs\(cq instead of
 .PP
 Values containing spaces, tabs or # may instead be enclosed in double quotes.
 But \(dq and \(cq must be escaped even within double quotes. If the starting line
-of a section is enclosed in double quotes, the square brakets must be within
+of a section is enclosed in double quotes, the square brackets must be within
 the quotes (like \(dq[/home/otto/with space]\(dq).
 
 .PP
@@ -251,7 +251,7 @@ Default: 0
 .TP
 .B if_match_bug
 Some servers do not handle If-Match and If-None-Match-headers correctly.
-This option tells \fB@PROGRAM_NAME@\fR to use HEAD instead of thes headers.
+This option tells \fB@PROGRAM_NAME@\fR to use HEAD instead of these headers.
 0 = no, 1 = yes.
 .br
 Default: 0

--- a/man/mount.davfs.8
+++ b/man/mount.davfs.8
@@ -185,7 +185,7 @@ Default: ordinary users are not allowed to mount.
 .TP
 .B users
 Like \fBuser\fR, but \fBany\fR user is allowed to unmount the file system,
-not only the mounting user. This is generally not recomended.
+not only the mounting user. This is generally not recommended.
 If the \fBuser\fR option allows an unprivileged user to mount, but unmounting by
 the mounting user fails the \fBusers\fR may be a work around.
 .br
@@ -330,7 +330,7 @@ even happen without intention).
 \fB@PROGRAM_NAME@\fR will therefore check if the file has been changed on the
 the server before it uploads a new version. If it
 finds it impossible to upload the locally changed file, it will store it in
-the local backup direcotry \fIlost+found\fP. You should check this directory from
+the local backup directory \fIlost+found\fP. You should check this directory from
 time to time and decide what to do with this files.
 
 .PP
@@ -354,7 +354,7 @@ properly \fB@PROGRAM_NAME@\fR may not be able to access this files. You can use
 \fB@PACKAGE@\fR implements Unix permissions for access control. But
 changing owner and permissions of a file is only \fBlocal\fR. It is 
 intended as a means for the owner of the file system, to control whether
-other local users may acces this file system.
+other local users may access this file system.
 
 .PP
 The server does not know about this. From the servers point of view there is
@@ -369,8 +369,8 @@ on the local system is still controlled by mount options and local permissions.
 
 .PP
 When the file system is unmounted, attributes of cached files (including
-owner and permissions) are stored in cache, as well as the attributs of
-the direcotries they are in. But there is no information stored about
+owner and permissions) are stored in cache, as well as the attributes of
+the directories they are in. But there is no information stored about
 directories that do not contain cached files.
 
 

--- a/src/cache.c
+++ b/src/cache.c
@@ -1684,7 +1684,7 @@ backup_node(dav_node *orig)
      If it can not be safed, a local backup is created and the node is deleted. 
    - removes any file nodes without cached file
    - removes all dir nodes that have not at least one file node below.
-   Short: removes everthing that is not necessary to correctly reference
+   Short: removes everything that is not necessary to correctly reference
    the cached files.
    Node node itself will be removed and deleted if possible.
    Directory backup and root will never be removed.
@@ -2007,7 +2007,7 @@ move_reg(dav_node *src, dav_node *dst, dav_node *dst_parent,
    into the child list of parent and the hash table. Member nref of the
    parent will be updated.
    parent : The parent of the new node, may be NULL.
-   mode   : Tthe mode of the new node.
+   mode   : The mode of the new node.
    return value : A pointer to the new node. */
 static dav_node *
 new_node(dav_node *parent, mode_t mode)
@@ -2121,7 +2121,7 @@ remove_from_tree(dav_node *node)
    Depending on the kind of node and its state additional action will be taken:
    - For directories the complete tree below is removed too.
    - If a regular file is dirty, open for writing or created, a backup in
-     driectory backup will be created, that holds the cached local copy of the
+     directory backup will be created, that holds the cached local copy of the
      file.
    - If a file is open, it will not be removed from the hash table to allow
      proper closing of open file descriptors. */
@@ -2423,7 +2423,7 @@ get_file_handle(dav_node * node, int fd, int accmode, pid_t pid, pid_t pgid)
 /* Checks whether user uid has access to node according to how.
    In any case the user must have execute permission for the parent of node
    and all of its parents up to the root node.
-   int how : How to acces the node. May be any combination of R_OK, W_OK, X_OK
+   int how : How to access the node. May be any combination of R_OK, W_OK, X_OK
              and F_OK.
    return value: 1 access is allowed.
                  0 access is denied. */
@@ -2751,7 +2751,7 @@ write_dir(dav_node *dir, int fd)
    message and terminate the program.
    dir    : The top level cache directory.
    host   : Domain name of the server.
-   path   : Path of the resource onthe server.
+   path   : Path of the resource on the server.
    mpoint : Mount point. */
 static void
 check_cache_dir(const char *dir, const char *host, const char *path,
@@ -3138,7 +3138,7 @@ xml_cdata(void *userdata, int state, const char *cdata, size_t len)
 
 /* Finishes the creation of directory backup.
    userdata is set to the parent of backup.
-   return value : allways 0. */
+   return value : always 0. */
 static int
 xml_end_backup(void *userdata, int state, const char *nspace, const char *name)
 {
@@ -3251,9 +3251,9 @@ xml_end_decimal(void *userdata, int state, const char *nspace,
 
 
 /* Finishes the creation of a directory. Members name and path of the
-   not must not be NULL, or the direcotry tree will be deleted.
+   not must not be NULL, or the directory tree will be deleted.
    userdata is set to the parent of the directory.
-   return value : allways 0. */
+   return value : always 0. */
 static int
 xml_end_dir(void *userdata, int state, const char *nspace, const char *name)
 {
@@ -3305,7 +3305,7 @@ xml_end_mode(void *userdata, int state, const char *nspace, const char *name)
    will be deleted.
    If the file is in directory backup, member path may be NULL.
    userdata is set to the parent of the file node.
-   return value : allways 0. */
+   return value : always 0. */
 static int
 xml_end_reg(void *userdata, int state, const char *nspace, const char *name)
 {
@@ -3347,7 +3347,7 @@ xml_end_reg(void *userdata, int state, const char *nspace, const char *name)
 /* Finishes the creation of the root directory. userdata must be equal to root,
    or the complete tree will be deleted.
    Members path, name, cache_path and etag will be NULL.
-   return value : allways 0. */
+   return value : always 0. */
 static int
 xml_end_root(void *userdata, int state, const char *nspace, const char *name)
 {
@@ -3475,7 +3475,7 @@ xml_end_string_old(void *userdata, int state, const char *nspace,
 
 
 /* Will be called when the start tag of a XML-element is found, and tests
-   wheather it is a BACKUP elemt. In this case parent must be ROOT.
+   wheather it is a BACKUP element. In this case parent must be ROOT.
    userdata will be set to the newly created node backup and also the global
    variable backup will be set.
    return value : 0 not responsible for this kind of element.

--- a/src/cache.c
+++ b/src/cache.c
@@ -1628,7 +1628,7 @@ add_node(dav_node *parent, dav_props *props)
 }
 
 
-/* Checks whether node is allready in the list of changed nodes. If not
+/* Checks whether node is already in the list of changed nodes. If not
    it will be appended at the end of the list. */
 static void
 add_to_changed(dav_node *node)
@@ -1783,7 +1783,7 @@ delete_node(dav_node *node)
 /* Deletes the tree starting at and including node. The tree is freed
    uncontionally, no checks for lost update problem and the like are
    done, also backup will be deleted if in tree.
-   Exeption: the root node will not be deleted. */
+   Exception: the root node will not be deleted. */
 static void
 delete_tree(dav_node *node)
 {
@@ -3475,7 +3475,7 @@ xml_end_string_old(void *userdata, int state, const char *nspace,
 
 
 /* Will be called when the start tag of a XML-element is found, and tests
-   wheather it is a BACKUP element. In this case parent must be ROOT.
+   whether it is a BACKUP element. In this case parent must be ROOT.
    userdata will be set to the newly created node backup and also the global
    variable backup will be set.
    return value : 0 not responsible for this kind of element.

--- a/src/cache.h
+++ b/src/cache.h
@@ -51,7 +51,7 @@ struct dav_handle {
    Nodes that are direct childs of the same directory-node are linked together
    by the next-pointer to a linked list.
    The hierarchical directory structure is formed by pointers to the parent
-   direcotry and to the first member in the linked list of direct childs.
+   directory and to the first member in the linked list of direct childs.
    Nodes are also stored in a hash table. The hash is derived from the nodes
    address. Nodes with the same hash value are linked together by table_next. */
 typedef struct dav_node dav_node;
@@ -115,7 +115,7 @@ struct dav_node {
               0 if not locked. -1 locked infinitely. */
     time_t lock_expire;
     /* Directories: Number of subdirectories, including "." and "..".
-       Files: Allways 1. */
+       Files: Always 1. */
     int nref;
     /* Files: File exists on the server. For locally created files that have
               not been put to the server it will be 0.
@@ -182,9 +182,9 @@ typedef off_t (*dav_write_dir_entry_fn)(int fd, off_t off, const dav_node *node,
    If the connection to the server fails because of authentication failure
    it prints an error message and terminates the programm. If the connection
    fails due to other reasons, it will nevertheless return with success, as the
-   filesystem can be mounted, but will only get useable when the connection
+   filesystem can be mounted, but will only get usable when the connection
    comes up.
-   paramters: if not self explaining, please see mount_davfs.c, struct args. */
+   parameters: if not self explaining, please see mount_davfs.c, struct args. */
 void
 dav_init_cache(const dav_args *args, const char *mpoint);
 
@@ -202,7 +202,7 @@ dav_close_cache(volatile int *got_sigterm);
 
 /* Registers the kernel_interface.
    Sets pointers to the write_dir_entry_fn flush_flag.
-   If blksize is not NULL, the preferred bloksize for IO is asigned.
+   If blksize is not NULL, the preferred bloksize for IO is assigned.
    It returns the value of alignment. */
 size_t
 dav_register_kernel_interface(dav_write_dir_entry_fn write_fn,
@@ -236,7 +236,7 @@ dav_tidy_cache(void);
 
    Common return values:
    0       Success.
-   EACCES  Access is denied to user uid according to the acces bits.
+   EACCES  Access is denied to user uid according to the access bits.
    EAGAIN  A temporary failure in the connection to the WebDAV server.
    EBUSY   The action on the node can not be performed, as somebody else uses
            it allready in a way that would collide with the requested action.
@@ -252,7 +252,7 @@ dav_tidy_cache(void);
 
 
 /* Tests whether user uid has access described by how to node.
-   int how : A bit mask describing the kind of acces. It may be any combination
+   int how : A bit mask describing the kind of access. It may be any combination
              of R_OK, W_OK, X_OK and F_OK. */
 int
 dav_access(dav_node *node, uid_t uid, int how);
@@ -298,7 +298,7 @@ int
 dav_lookup(dav_node **nodep, dav_node *parent, const char *name, uid_t uid);
 
 
-/* Creates a new directory named name in direcotry parent. The directory must
+/* Creates a new directory named name in directory parent. The directory must
    not yet exist. The new node is returned in nodep.
    Owner will be uid, group the primary group of uid. Mode will be mode with
    the bits from dir_umask removed.
@@ -359,7 +359,7 @@ dav_rename(dav_node *src_parent, const char *src_name, dav_node *dst_parent,
            const char *dst_name, uid_t uid);
 
 
-/* Removes direcotry name in directory parent.
+/* Removes directory name in directory parent.
    The directory must be empty and not the local backup directory.
    uid must have execute permission for parent and all of its ancestors, as
    well as write permission for parent. */

--- a/src/cache.h
+++ b/src/cache.h
@@ -160,7 +160,7 @@ struct dav_stat {
 /* Call back function that writes a directory entry to file descriptor fd.
    fd     : An open file descriptor to write to.
    off    : The current file size.
-   node   : The pointer to node is taken as inode/file number (shrinked to
+   node   : The pointer to node is taken as inode/file number (shrunk to
             fit if necessary).
    name   : File name; if NULL, the last, empty entry is written (if the
             kernel file system wants one).
@@ -180,7 +180,7 @@ typedef off_t (*dav_write_dir_entry_fn)(int fd, off_t off, const dav_node *node,
    Creates the root node and restores the nodes from the permanent cache.
    Finally it retrieves the root directory entries from the server.
    If the connection to the server fails because of authentication failure
-   it prints an error message and terminates the programm. If the connection
+   it prints an error message and terminates the program. If the connection
    fails due to other reasons, it will nevertheless return with success, as the
    filesystem can be mounted, but will only get usable when the connection
    comes up.
@@ -239,8 +239,8 @@ dav_tidy_cache(void);
    EACCES  Access is denied to user uid according to the access bits.
    EAGAIN  A temporary failure in the connection to the WebDAV server.
    EBUSY   The action on the node can not be performed, as somebody else uses
-           it allready in a way that would collide with the requested action.
-   EEXIST  Cration of a new node is requested with flag O_EXCL, but it exists.
+           it already in a way that would collide with the requested action.
+   EEXIST  Creation of a new node is requested with flag O_EXCL, but it exists.
    EINVAL  One of the parameters has an invalid value.
    EIO     Error performing I/O-operation. Usually there are problems in the
            communication with the WebDAV server.
@@ -269,7 +269,7 @@ dav_close(dav_node *node, int fd, int flags, pid_t pid, pid_t pgid);
 
 /* Creates a new file node with name name in directory parent. The file is
    locked on the server. The new node is returned in nodep.
-   There must no node with name name allready exist in parent.
+   There must no node with name name already exist in parent.
    The new node is owned by uid; group is the primary group of uid.  Mode is
    set to mode, but with the bits from file_umask removed.
    Permissions:
@@ -347,7 +347,7 @@ dav_remove(dav_node *parent, const char *name, uid_t uid);
 
 /* Moves file or directory src_name from directory src_parent to directory
    dst_parent and renames it to dst_name.
-   If dst_name allready exists in dst_parent and is a directory, there must
+   If dst_name already exists in dst_parent and is a directory, there must
    be no files opened for writing in it.
    Moves into the backup directory are not allowed.
    Permissions:

--- a/src/dav_fuse.c
+++ b/src/dav_fuse.c
@@ -425,7 +425,7 @@ dav_fuse_loop(int device, char *mpoint, size_t bufsize, time_t idle_time,
 /* Functions to handle upcalls from the kernel module.
    The cache module only uses data types from the C-library. For file access,
    mode and the like it only uses symbolic constants defined in the C-library.
-   So the main porpose of this functions is to translate from kernel specific
+   So the main purpose of this functions is to translate from kernel specific
    types and constants to types and constants from the C-library, and back.
    All of this functions return the amount of data in buf that is to be
    send to the kernel module. */

--- a/src/dav_fuse.c
+++ b/src/dav_fuse.c
@@ -91,7 +91,7 @@ static int debug;
 /* Private function prototypes */
 /*=============================*/
 
-/* Functions to handle upcalls fromthe kernel module. */
+/* Functions to handle upcalls from the kernel module. */
 
 static uint32_t
 fuse_access(void);
@@ -422,7 +422,7 @@ dav_fuse_loop(int device, char *mpoint, size_t bufsize, time_t idle_time,
 /* Private functions */
 /*===================*/
 
-/* Functions to handle upcalls fromthe kernel module.
+/* Functions to handle upcalls from the kernel module.
    The cache module only uses data types from the C-library. For file access,
    mode and the like it only uses symbolic constants defined in the C-library.
    So the main porpose of this functions is to translate from kernel specific

--- a/src/defaults.h
+++ b/src/defaults.h
@@ -1,4 +1,4 @@
-/*  defauls.h: default values of configuration options and constants.
+/*  defaults.h: default values of configuration options and constants.
     Copyright (C) 2006, 2007, 2008, 2009, 2014 Werner Baumann
 
     This file is part of davfs2.

--- a/src/defaults.h
+++ b/src/defaults.h
@@ -40,7 +40,7 @@
    ordinary user. */
 #define DAV_USER_MOPTS (MS_MGC_VAL | MS_NOSUID | MS_NOEXEC | MS_NODEV)
 
-/* This mount options will allways be set by davfs2. Different values from
+/* This mount options will always be set by davfs2. Different values from
    command line and even fstab will be silently ignored. */
 #define DAV_MOPTS (MS_MGC_VAL | MS_NOSUID | MS_NODEV)
 
@@ -176,7 +176,7 @@
 #define DAV_N_COOKIES 0
 
 /* Check on server whether a file exists or has been modified before
-   locking a new file or changing an existant one.
+   locking a new file or changing an existent one.
    May be overridden by system config file and user config file. */
 #define DAV_PRECHECK 1
 
@@ -203,7 +203,7 @@
 
 /* Timeout in seconds used when libneon supports non blocking io
    A value of zero means use the TCP default
-   May be overriden by system config file and user config file. */
+   May be overridden by system config file and user config file. */
 #define DAV_CONNECT_TIMEOUT 10
 
 /* Timeout in seconds used when reading from a socket.

--- a/src/kernel_interface.h
+++ b/src/kernel_interface.h
@@ -1,4 +1,4 @@
-/*  kernel_interface.h: interface to fuse and coda kernel mocule.
+/*  kernel_interface.h: interface to fuse and coda kernel module.
     Copyright (C) 2006, 2007, 2008, 2009, 2020 Werner Baumann
 
     This file is part of davfs2.

--- a/src/mount_davfs.c
+++ b/src/mount_davfs.c
@@ -428,7 +428,7 @@ change_persona(dav_args *args)
 }
 
 
-/* Checks for the existence of necessary and usefull directories and files.
+/* Checks for the existence of necessary and useful directories and files.
    - checks whether it can use the proc file system for information about
      mounted file systems, or has to use mtab
    - whether the directory to save pid files exists and has correct owner and
@@ -815,7 +815,7 @@ check_permissions(dav_args *args)
     }
     if (args->debug & DAV_DBG_CONFIG)
         syslog(LOG_MAKEPRI(LOG_DAEMON, LOG_DEBUG),
-               "memeber of group %s", args->dav_group);
+               "member of group %s", args->dav_group);
 }
 
 
@@ -894,7 +894,7 @@ is_mounted(void)
    it prints an error message and calls exit(EXIT_FAILURE).
    argc    : the number of arguments.
    argv[]  : array of argument strings.
-   return value : args, containig the parsed options and arguments. The args
+   return value : args, containing the parsed options and arguments. The args
                   structure and all strings are newly allocated. The calling
                   function is responsible to free them. */
 static dav_args *
@@ -1154,7 +1154,7 @@ parse_config(dav_args *args)
 }
 
 
-/* Reads the secrets file and asks the user interactivly for credentials if
+/* Reads the secrets file and asks the user interactively for credentials if
    necessary. The user secrets file is parsed after the system wide secrets
    file, so it will have precedence. */
 static void
@@ -1970,7 +1970,7 @@ log_dbg_config(dav_args *args)
              parameters are found
    parmv[] : the parameters found are returned in this array. It contains
              pointers into the rearranged line parameter.
-   reurn value : the numer of parameters or -1 if an error occurs. */
+   return value : the number of parameters or -1 if an error occurs. */
 static int
 parse_line(char *line, int parmc, char *parmv[])
 {

--- a/src/mount_davfs.c
+++ b/src/mount_davfs.c
@@ -435,7 +435,7 @@ change_persona(dav_args *args)
      permissions; if not it tries to create it and/or set owner and permissions
    - when invoked by non-root user: checks for configuration directory in the
      users homepage and creates missing directories and files
-   - checks wether args->cache_dir is accessible. */
+   - checks whether args->cache_dir is accessible. */
 static void
 check_dirs(dav_args *args)
 {
@@ -819,7 +819,7 @@ check_permissions(dav_args *args)
 }
 
 
-/* Checks wether the file system is mounted.
+/* Checks whether the file system is mounted.
    It uses information from the private global variables mounts (mtab-file),
    url (must be device in the mtab entry) and mpoint (mount point).
    return value : 0 - no matching entry in the mtab-file (not mounted)
@@ -1960,7 +1960,7 @@ log_dbg_config(dav_args *args)
    is ignored.
    Parameters containing one of the characters ' ' (space), '\t' (tab), '\',
    '"' or '#' must be enclosed in double quotes '"' *or* this character has to
-   be escaped by preceeding a '\'-character.
+   be escaped by preceding a '\'-character.
    Inside double quotes the '"'-character must be escaped. '\' may be escaped;
    it must be escaped if there is more than on '\'-character in succession.
    Whitespace characters other than ' ' and tab must only occur at the end of
@@ -2503,7 +2503,7 @@ read_secrets(dav_args *args, const char *filename)
    in square brackets.
    The pointers to the components may be NULL. If they point to a non-NULL
    string, it is freed and then replaced by a newly allocated string.
-   If no scheme is foud the default sheme "http" is returned.
+   If no scheme is foud the default scheme "http" is returned.
    If no path is found "/" is returned as path. path will always end with "/".
    There is *no* default value returned for port.
    return value : 0 on success, -1 otherwise. */

--- a/src/mount_davfs.h
+++ b/src/mount_davfs.h
@@ -126,7 +126,7 @@ typedef struct {
    Step 2:
    - The modules for connecting to the kernel, connecting to the WebDAV resource
      and for caching are initialised.
-   If an error accurs during step 1 or step 2 an error message is printed and
+   If an error occurs during step 1 or step 2 an error message is printed and
    the program dies immediately. Clean up is left to the operating system.
    Step 3:
    - Forking into daemon mode.
@@ -145,7 +145,7 @@ typedef struct {
    - The daemon has set a signal handler for SIGTERM and SIGHUP. If it gets one
      of these signals it tries to unmount the file system and resets the global
      variable keep_on_running. This will terminate the message loop gracefully.
-   - If the file system is unmounted (by the umount programm), the message
+   - If the file system is unmounted (by the umount program), the message
      loop will terminate gracefully.
    - The close functions of the modules are called, that will clean up the
      cache, save cached information if necessary and close the connections. */

--- a/src/mount_davfs.h
+++ b/src/mount_davfs.h
@@ -121,7 +121,7 @@ typedef struct {
    - Checking this information for consistency and any errors that would
      prevent successful running of the daemon.
    - Checking whether the the user has permissions to mount.
-   - Checking whether the neccessary files and directories for running the
+   - Checking whether the necessary files and directories for running the
      daemon are available.
    Step 2:
    - The modules for connecting to the kernel, connecting to the WebDAV resource
@@ -148,7 +148,7 @@ typedef struct {
    - If the file system is unmounted (by the umount programm), the message
      loop will terminate gracefully.
    - The close functions of the modules are called, that will clean up the
-     cache, save cached information if neccessary and close the connections. */
+     cache, save cached information if necessary and close the connections. */
 int
 main(int argc, char *argv[]);
 

--- a/src/umount_davfs.c
+++ b/src/umount_davfs.c
@@ -182,7 +182,7 @@ main(int argc, char *argv[])
         WARN(_("\n"
                "  can't find %s-process with pid %s;\n"
                "  trying to unmount anyway.\n"
-               "  you propably have to remove %s manually"),
+               "  you probably have to remove %s manually"),
              PROGRAM_NAME, pid, pidfile);
         return system(umount_command);
     }

--- a/src/webdav.c
+++ b/src/webdav.c
@@ -94,7 +94,7 @@ typedef struct {
 } propfind_context;
 
 typedef struct {
-    int error;                  /* An error occured while reading/writing. */
+    int error;                  /* An error occurred while reading/writing. */
     const char *file;           /* cache_file to store the data in. */
     int fd;                     /* file descriptor of the open cache file. */
 } get_context;
@@ -1476,7 +1476,7 @@ get_ne_error(const char *method, ne_session *sess)
 
 
 /* Searches for a lock for resource at path and returns
-   this lock if successfull, NULL otherwise. */
+   this lock if successful, NULL otherwise. */
 static struct ne_lock *
 lock_by_path(const char *path)
 {
@@ -1574,9 +1574,9 @@ log_writer(void *cookie, const char *buffer, size_t size)
 
 
 /* Checks etag for weakness indicator and quotation marks.
-   The reurn value is either a strong etag with quotation marks or NULL.
+   The return value is either a strong etag with quotation marks or NULL.
    Depending on global variable drop_weak_etags weak etags are either
-   dropped or convertet into strong ones. */
+   dropped or converted into strong ones. */
 static char *
 normalize_etag(const char *etag)
 {
@@ -1664,7 +1664,7 @@ add_header(ne_request *req, void *userdata, ne_buffer *header)
    returned, so neon will not try again.
    userdata : What the credentials are needed for ("server" or "proxy").
    realm    : Used for error log.
-   attempt  : Number of attempts to get credentials. If not 0 an error occured.
+   attempt  : Number of attempts to get credentials. If not 0 an error occurred.
    user     : A buffer of size NE_ABUFSIZ to return the username.
    pwd      : A buffer of size NE_ABUFSIZ to return the password.
    return value : value if attempt. neon will not call this function again if
@@ -1731,7 +1731,7 @@ file_reader(void *userdata, const char *block, size_t length)
 
 
 /* A ne_post_header_fn to read cookies from the Set-Cookie header and
-   store them in the global arrray of strings cookie_list. The cookies
+   store them in the global array of strings cookie_list. The cookies
    will be send in the Cookie header of subsequent requests.
    Only the "name=value" part of the cookie is stored. All attributes
    are completely ignored.

--- a/src/webdav.h
+++ b/src/webdav.h
@@ -170,8 +170,8 @@ int
 dav_head(const char *path, char **etag, time_t *mtime, off_t *length);
 
 
-/* Locks the file path on the server with an excluse write lock and updates
-   expire and exists. If a lock for path allready exists it will be refreshed.
+/* Locks the file path on the server with an exclusive write lock and updates
+   expire and exists. If a lock for path already exists it will be refreshed.
    On success expire will be updated to the time when the lock expires.
    If the file does not yet exist and server creates a new file (as opposed to
    creating a locked-null-resource) exists will be set to 1.

--- a/src/webdav.h
+++ b/src/webdav.h
@@ -38,8 +38,8 @@ struct dav_props {
     off_t size;         /* File size in bytes (regular files only). */
     time_t mtime;       /* Date of last modification. */
     int is_dir;         /* Boolean; 1 if a directory. */
-    int is_exec;        /* -1 if not specified; 1 is executeable;
-                           0 not executeable. */
+    int is_exec;        /* -1 if not specified; 1 is executable;
+                           0 not executable. */
     dav_props *next;    /* Next in the list. */
 };
 
@@ -52,7 +52,7 @@ struct dav_props {
    If the server does not support class 2, locking is disabled.
    It must only be initialized once, as it depends on global variables.
    If an error occurs, the program is terminated.
-   paramters: if not self explaining, please see mount_davfs.h, struct args. */
+   parameters: if not self explaining, please see mount_davfs.h, struct args. */
 void
 dav_init_webdav(const dav_args* args);
 
@@ -62,7 +62,7 @@ dav_init_webdav(const dav_args* args);
    does not support locks, it will remove the lockstore and set locks
    to NULL.
    path : Path to the root collection.
-   return value : 0 on success or an apropriate error code. */
+   return value : 0 on success or an appropriate error code. */
 int
 dav_init_connection(const char *path);
 
@@ -112,7 +112,7 @@ dav_delete_props(dav_props *props);
 
 /* Retrieves properties for the directory named by path and its
    direct childs (depth 1) from the server.
-   The properties are returned as a linked list of dav_props. If successfull,
+   The properties are returned as a linked list of dav_props. If successful,
    this list contains at least one entry (the directory itself; its name is
    the empty string). The calling function is responsible for freeing the list
    and all the strings included.
@@ -150,9 +150,9 @@ dav_get_file(const char *path, const char *cache_path, off_t *size,
 
 
 /* Returns the error string from the last WebDAV request.
-   Note: This will not be usefull in any case, because the last function
+   Note: This will not be useful in any case, because the last function
          called may have done more then one request (e.g. an additional
-         lock discover. But it is usefull for dav_get_collection(). */
+         lock discover. But it is useful for dav_get_collection(). */
 const char *
 dav_get_webdav_error(void);
 
@@ -181,7 +181,7 @@ dav_head(const char *path, char **etag, time_t *mtime, off_t *length);
    If it can't get a lock it will return an appropriate error code and set
    expire to 0.
    If the session is initialized with the nolocks option, it does nothing,
-   but allways returns success and sets expire to 0.
+   but always returns success and sets expire to 0.
    path    : absolute path of the file on the server.
    expire  : Points to the time when the lock expires. 0 if not locked.
              Will be updated.
@@ -262,7 +262,7 @@ dav_set_no_terminal(void);
 
 /* Releases the lock on file path on the serverand sets expire to 0.
    path : Absolute path of the file on the server.
-   return value : 0 if no error occured; an appropriate file error code
+   return value : 0 if no error occurred; an appropriate file error code
                   otherwise. */
 int
 dav_unlock(const char *path, time_t *expire);


### PR DESCRIPTION
More about codespell: https://github.com/codespell-project/codespell .

I personally introduced it to dozens if not hundreds of projects already and so far only positive feedback.

CI workflow has 'permissions' set only to 'read' so also should be safe.